### PR TITLE
fix small bug in trainer_ac.py for multi-gpu training

### DIFF
--- a/rainbowneko/train/trainer/trainer_ac.py
+++ b/rainbowneko/train/trainer/trainer_ac.py
@@ -229,7 +229,7 @@ class Trainer:
 
     @property
     def model_raw(self):
-        return self.model_wrapper.module
+        return self.model_wrapper
 
     def config_model(self):
         if self.cfgs.model.enable_xformers:


### PR DESCRIPTION
Signed-off-by: Chengxing Zhou <zhouchx33@mail2.sysu.edu.cn>

During my training with `neko_train --cfg xxxxxx.py`, error appears in `rainbowneko/train/trainer/trainer_ac.py line232`, which says:
```
[rank0]: Traceback (most recent call last):
[rank0]:   File "xx/lib/python3.10/runpy.py", line 196, in _run_module_as_main
[rank0]:     return _run_code(code, main_globals, None,
[rank0]:   File "xx/lib/python3.10/runpy.py", line 86, in _run_code
[rank0]:     exec(code, run_globals)
[rank0]:   File "xxx/RainbowNekoEngine-dev/rainbowneko/train/trainer/trainer_ac.py", line 511, in <module>
[rank0]:     trainer.train()
[rank0]:   File "xxx/RainbowNekoEngine-dev/rainbowneko/train/trainer/trainer_ac.py", line 356, in train
[rank0]:     loss, pred_dict, inputs_dict = self.train_one_step(data_dict)
[rank0]:   File "xxx/RainbowNekoEngine-dev/rainbowneko/train/trainer/trainer_ac.py", line 449, in train_one_step
[rank0]:     self.model_raw.update_model(self.real_step)  # Some model may update by step
[rank0]:   File "xxx/RainbowNekoEngine-dev/rainbowneko/train/trainer/trainer_ac.py", line 232, in model_raw
[rank0]:     return self.model_wrapper.module
[rank0]:   File "xx/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1928, in __getattr__
[rank0]:     raise AttributeError(
[rank0]: AttributeError: 'DistillationWrapper' object has no attribute 'module'. Did you mean: 'modules'?
[rank1]: Traceback (most recent call last):
[rank1]:   File "xx/lib/python3.10/runpy.py", line 196, in _run_module_as_main
[rank1]:     return _run_code(code, main_globals, None,
[rank1]:   File "xx/lib/python3.10/runpy.py", line 86, in _run_code
[rank1]:     exec(code, run_globals)
[rank1]:   File "xxx/RainbowNekoEngine-dev/rainbowneko/train/trainer/trainer_ac.py", line 511, in <module>
[rank1]:     trainer.train()
[rank1]:   File "xxx/RainbowNekoEngine-dev/rainbowneko/train/trainer/trainer_ac.py", line 356, in train
[rank1]:     loss, pred_dict, inputs_dict = self.train_one_step(data_dict)
[rank1]:   File "xxx/RainbowNekoEngine-dev/rainbowneko/train/trainer/trainer_ac.py", line 449, in train_one_step
[rank1]:     self.model_raw.update_model(self.real_step)  # Some model may update by step
[rank1]:   File "xxx/RainbowNekoEngine-dev/rainbowneko/train/trainer/trainer_ac.py", line 232, in model_raw
[rank1]:     return self.model_wrapper.module
[rank1]:   File "xx/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1928, in __getattr__
[rank1]:     raise AttributeError(
[rank1]: AttributeError: 'DistillationWrapper' object has no attribute 'module'. Did you mean: 'modules'?
```
But this do not happen when I train by single GPU with `neko_train_1gpu --cfg xxxxxx.py`. So I compare `class TrainerSingleCard` with `class Trainer` in `rainbowneko/train/trainer`, finding that `def init_context`, `def boardcast_main` and  `def all_gather` are required to be modified to fit single GPU training, but maybe no need for `def model_raw`.
​As a result, I modify
```python
@property
def model_raw(self):
    return self.model_wrapper.module
```
to 
```python
@property
def model_raw(self):
    return self.model_wrapper
```
and solved this problem.