### PR TITLE
fix bugs for `load_all`

### DIFF
--- a/rainbowneko/ckpt_manager/base.py
+++ b/rainbowneko/ckpt_manager/base.py
@@ -5,7 +5,6 @@ from torch import nn
 from rainbowneko.models.plugin import PluginGroup
 from .format import CkptFormat, SafeTensorFormat
 from .source import LocalCkptSource
-from .ckpt import NekoPluginLoader, NekoModelLoader
 
 LAYERS_ALL = 'all'
 LAYERS_TRAINABLE = 'trainable'
@@ -31,10 +30,10 @@ class NekoLoader:
     @staticmethod
     def load_all(model: nn.Module, model_plugin: Dict[str, PluginGroup], cfg: Dict[str, "NekoLoader"]):
         for name, loader in cfg.items():
-            if isinstance(loader, NekoPluginLoader):
-                loader.load_to(name, model_plugin)
-            elif isinstance(loader, NekoModelLoader):
+            if hasattr(loader, 'target_module'): # specific for `NekoModelLoader`
                 loader.load_to(name, model)
+            elif hasattr(loader, 'target_plugin'): # specific for `NekoPluginLoader`
+                loader.load_to(name, model_plugin)
 
 
 class NekoSaver:


### PR DESCRIPTION
original `from .ckpt import NekoPluginLoader, NekoModelLoader ` (import children class in parent scripts), will meet:
> ImportError: cannot import name 'NekoLoader' from partially initialized module 'rainbowneko.ckpt_manager.base' (most likely due to a circular import) (XXX/rainbowneko/ckpt_manager/base.py)

Now, I use unique attributes as judgment condition.